### PR TITLE
Add a context instance variable to Action

### DIFF
--- a/crack_pipe.gemspec
+++ b/crack_pipe.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',  '> 1.16'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'pry',      '~> 0.12.1'
-  s.add_development_dependency 'pry-byebug',      '> 3.0.0'
+  s.add_development_dependency 'pry-byebug', '> 3.0.0'
   s.add_development_dependency 'rake',     '~> 10.0'
 end

--- a/crack_pipe.gemspec
+++ b/crack_pipe.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
   s.files         = %w[LICENSE.txt README.md] + Dir['lib/**/*.rb']
   s.require_paths = %w[lib]
 
-  s.add_development_dependency 'bundler',  '~> 1.16'
+  s.add_development_dependency 'bundler',  '> 1.16'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'pry',      '~> 0.12.1'
+  s.add_development_dependency 'pry-byebug',      '> 3.0.0'
   s.add_development_dependency 'rake',     '~> 10.0'
 end

--- a/lib/crack_pipe/action.rb
+++ b/lib/crack_pipe/action.rb
@@ -13,6 +13,8 @@ module CrackPipe
   class Action
     @steps = []
 
+    attr_accessor :context
+
     class << self
       attr_reader :steps
 

--- a/lib/crack_pipe/action.rb
+++ b/lib/crack_pipe/action.rb
@@ -13,7 +13,7 @@ module CrackPipe
   class Action
     @steps = []
 
-    attr_accessor :context
+    attr_accessor :context, :atts
 
     class << self
       attr_reader :steps

--- a/lib/crack_pipe/action/exec.rb
+++ b/lib/crack_pipe/action/exec.rb
@@ -80,11 +80,24 @@ module CrackPipe
         end
 
         def exec_with_args(e, action, context, kwargs)
+          action.context = context
+
           if e.is_a?(Symbol)
-            action.public_send(e, context, **kwargs)
+            if ctx_expected_as_arg?(action.method(e))
+              # DEPRECATED! :>
+              action.public_send(e, context, **kwargs)
+            else
+              # NEW HOTNESS! :>
+              action.public_send(e)
+            end
           else
             e.call(context, **kwargs)
           end
+        end
+
+        def ctx_expected_as_arg?(method)
+          method.arity.nonzero? &&
+            (method.parameters.flatten & %i[ctx _ _ctx]).any?
         end
 
         def kwargs_with_context(action, context)

--- a/lib/crack_pipe/action/exec.rb
+++ b/lib/crack_pipe/action/exec.rb
@@ -96,8 +96,7 @@ module CrackPipe
         end
 
         def ctx_expected_as_arg?(method)
-          method.arity.nonzero? &&
-            (method.parameters.flatten & %i[ctx _ _ctx]).any?
+          method.arity.nonzero?
         end
 
         def kwargs_with_context(action, context)

--- a/lib/crack_pipe/action/exec.rb
+++ b/lib/crack_pipe/action/exec.rb
@@ -81,13 +81,13 @@ module CrackPipe
 
         def exec_with_args(e, action, context, kwargs)
           action.context = context
+          action.atts = context[:atts]
 
           if e.is_a?(Symbol)
             if ctx_expected_as_arg?(action.method(e))
-              # DEPRECATED! :>
+              # DEPRECATED
               action.public_send(e, context, **kwargs)
             else
-              # NEW HOTNESS! :>
               action.public_send(e)
             end
           else


### PR DESCRIPTION
In the prime_trust_api codebase, every step in every action passes around a `ctx` hash as the first argument. This hash is used to store request `atts`, the `resource` to be serialized in the response, and many other values that we build up along the path from request -> response.

Instead of passing this `ctx` hash around to each step, it could be an instance variable on the Action class.

The benefit of this approach is that the implementation of steps and action classes as a whole become a lot cleaner.

Example:

### Before, passing around `ctx`

```ruby
    class Create < V2::Action
      step :set_bank_account_id
      step :set_created_by_user_id
      step :create_uploaded_document
      step :create_incoming_wire_batch

      def set_bank_account_id(_, atts:, **)
        atts[:bank_account_id] ||= BankAccount.with_special_role('default_wire_USD').id
      end

      def set_created_by_user_id(_, atts:, current_user:, **)
        atts[:created_by_user_id] = current_user.id
      end

      def create_uploaded_document(_, atts:, **)
        return true unless atts[:file]
        atts[:uploaded_document_id] =
          UploadedDocument::Create.with_rack(atts[:file], extension: '.csv').id
      end

      def create_incoming_wire_batch(ctx, atts:, **)
        ctx[:resource] = IncomingWireBatch::Create.(atts)
      end
  end
```

### After, with instance variable `context`

```ruby
    class Create < V2::Action
      step :set_bank_account_id
      step :set_created_by_user_id
      step :create_uploaded_document
      step :create_incoming_wire_batch

      def set_bank_account_id
        atts[:bank_account_id] ||= BankAccount.with_special_role('default_wire_USD').id
      end

      def set_created_by_user_id
        atts[:created_by_user_id] = current_user.id
      end

      def create_uploaded_document
        return true unless atts[:file]
        atts[:uploaded_document_id] =
          UploadedDocument::Create.with_rack(atts[:file], extension: '.csv').id
      end

      def create_incoming_wire_batch
        context[:resource] = IncomingWireBatch::Create.(atts)
      end
  end
```

### Implementation and backwards compatibility
The changes in this PR are fully backwards compatible with existing Action implementations. If the step accepts parameters, it will continue to function as it does in `master`.

Moving forward, we could consider the old way of using `ctx` deprecated:
- New Actions are written without parameters
- Existing Actions continue to work, but should be updated if a major change is made within that Action

### TODO

- Add a Context class that inherits from Hashie::Mash or similar so we can use object notation (think `context.atts` or `context.resource`)
- Raise an exception if an attempt is made to access a key on `context` that does not exist